### PR TITLE
fix a broken link to GitHub Action

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,7 +31,7 @@
         <p>Extend terraform-docs by <a href="{{ "developer-guide/plugins/" | absURL }}">Plugin</a> and build your own formatter.</div>
       <div class="col-lg-5">
         <h2 class="h4">CI-friendly</h2>
-        <p>Automate document generation in pull requests with <a href="{{ "user-guide/how-to/github-action/" | absURL }}">GitHub Action</a>.</p>
+        <p>Automate document generation in pull requests with <a href="{{ "how-to/github-action/" | absURL }}">GitHub Action</a>.</p>
       </div>
     </div>
   </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,7 +31,7 @@
         <p>Extend terraform-docs by <a href="{{ "developer-guide/plugins/" | absURL }}">Plugin</a> and build your own formatter.</div>
       <div class="col-lg-5">
         <h2 class="h4">CI-friendly</h2>
-        <p>Automate document generation in pull requests with <a href="{{ "user-guide/how-to/" | absURL }}#github-action">GitHub Action</a>.</p>
+        <p>Automate document generation in pull requests with <a href="{{ "user-guide/how-to/github-action/" | absURL }}">GitHub Action</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The link to GitHub Action is broken.

<img width="1368" alt="image" src="https://github.com/user-attachments/assets/e71a7908-ccd3-4307-846a-ad11c7f4c658">

<img width="495" alt="image" src="https://github.com/user-attachments/assets/67b9fc4e-778b-415c-87f7-0c864fe6cbff">

https://terraform-docs.io/how-to/github-action/

I'm aware that the website content is managed at [terraform-docs/terraform-docs's docs directory](https://github.com/terraform-docs/terraform-docs/tree/master/docs), but seems like this page isn't managed there.

This page hasn't been updated by bot.

https://github.com/terraform-docs/website/commits/main/layouts/index.html